### PR TITLE
"Completed" basic SQL tables based on architecture.  

### DIFF
--- a/docker/db/Questivity DB First Draft.sql
+++ b/docker/db/Questivity DB First Draft.sql
@@ -1,0 +1,62 @@
+DROP TABLE accounts;
+
+CREATE TABLE Accounts (
+    user_id SERIAL PRIMARY KEY,
+    username VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    is_instructor BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE Account_Data (
+    user_id INT REFERENCES Accounts(user_id),
+    games_played INT DEFAULT 0,
+    experience_level INT DEFAULT 0,
+    PRIMARY KEY (user_id)
+);
+
+CREATE TABLE Courses (
+    course_id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    temporary_course_code CHAR(6) UNIQUE NOT NULL
+);
+
+CREATE TABLE Instructor_Courses (
+    user_id INT REFERENCES Accounts(user_id),
+    course_id INT REFERENCES Courses(course_id),
+    PRIMARY KEY (user_id, course_id)
+);
+
+CREATE TABLE Student_Courses (
+    user_id INT REFERENCES Accounts(user_id),
+    course_id INT REFERENCES Courses(course_id),
+    PRIMARY KEY (user_id, course_id)
+);
+
+CREATE TABLE Student_Progress (
+    course_id INT REFERENCES Courses(course_id),
+    user_id INT REFERENCES Accounts(user_id),
+    total_score INT DEFAULT 0,
+    PRIMARY KEY (course_id, user_id)
+);
+
+CREATE TABLE Achievements (
+    achievement_id SERIAL PRIMARY KEY,
+    achievement_image VARCHAR(255),
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    date_earned DATE
+);
+
+CREATE TABLE Account_Achievements (
+    user_id INT REFERENCES Accounts(user_id),
+    achievement_id INT REFERENCES Achievements(achievement_id),
+    PRIMARY KEY (user_id, achievement_id)
+);
+
+CREATE TABLE Game_Scores (
+    score_id SERIAL PRIMARY KEY,
+    course_id INT REFERENCES Courses(course_id),
+    user_id INT REFERENCES Accounts(user_id),
+    game_id INT NOT NULL,
+    date_earned DATE
+);


### PR DESCRIPTION
Forgot to delete the first draft so I'm unsure if there will be conflicts there. 

Additions: 
Tables accounts, account_data, courses, instructor_courses, student_courses, student_progress, achievements, account_achievements, and game_scores are created with corresponding linked keys. 

Note: 
Up from first draft's skeleton of the basic tables outlined in the first iteration of the SQL section of server architecture.  

**I'm not entirely sure how the two files existing at once will work. At worst we made need to push a modified version of this one that drops ALL tables just to be sure**